### PR TITLE
Fix compilation of example

### DIFF
--- a/poke.incl
+++ b/poke.incl
@@ -439,4 +439,4 @@ make_poke_map! {
 437,"Unown","Psychic",;
 438,"Unown","Psychic",;
 439,"Unown","Psychic",;
-};
+}


### PR DESCRIPTION
Including the semi-colon causes the following error:

error: include macro expected single expression in source